### PR TITLE
Fix a bug in Phoenix project when digesting

### DIFF
--- a/priv/template/_.dockerignore.eex
+++ b/priv/template/_.dockerignore.eex
@@ -4,3 +4,4 @@
 # prebuilt folder to speed up docker image generating.
 _build/
 deps/
+node_modules/


### PR DESCRIPTION
fix #1 

Add `node_modules` to the docker ignoring list to solve the failure.